### PR TITLE
Generate JSON decoder/encoder based on type-definiton

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,7 +17,8 @@
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
-        "elm/url": "1.0.0 <= v < 2.0.0"
+        "elm/url": "1.0.0 <= v < 2.0.0",
+        "stil4m/elm-syntax": "7.1.0 <= v < 8.0.0"
     },
     "test-dependencies": {}
 }

--- a/src/Json/Derive.elm
+++ b/src/Json/Derive.elm
@@ -1,0 +1,30 @@
+module Json.Derive exposing
+    ( customTypeToDecoder
+    , customTypeToEncoder
+    , typeAliasToDecoder
+    , typeAliasToEncoder
+    )
+
+import Elm.Syntax.Expression exposing (Function)
+import Elm.Syntax.Type exposing (Type)
+import Elm.Syntax.TypeAlias exposing (TypeAlias)
+
+
+typeAliasToEncoder : TypeAlias -> Function
+typeAliasToEncoder typeAlias =
+    Debug.todo "not implemented yet"
+
+
+customTypeToEncoder : Type -> Function
+customTypeToEncoder customType =
+    Debug.todo "not implemented yet"
+
+
+typeAliasToDecoder : TypeAlias -> Function
+typeAliasToDecoder typeAlias =
+    Debug.todo "not implemented yet"
+
+
+customTypeToDecoder : Type -> Function
+customTypeToDecoder customType =
+    Debug.todo "not implemented yet"


### PR DESCRIPTION
This merge will address #19. The goal is to have a CLI where you can specify a module and a type, and have it generate an encoder and decoder for that type, if it resides in the specified module with all of its substructure exposed.