### PR TITLE
Generate JSON decoder/encoder based on type-definiton

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -18,7 +18,8 @@
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
         "elm/url": "1.0.0 <= v < 2.0.0",
-        "klazuka/elm-json-tree-view": "2.0.0 <= v < 3.0.0"
+        "klazuka/elm-json-tree-view": "2.0.0 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.1.0 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.1 <= v < 2.0.0"

--- a/src/Elm/Syntax/Json.elm
+++ b/src/Elm/Syntax/Json.elm
@@ -1,0 +1,38 @@
+module Elm.Syntax.Json exposing
+    ( decoderForCustomType
+    , decoderForTypeAlias
+    , encoderForCustomType
+    , encoderForTypeAlias
+    )
+
+import Elm.Syntax.Expression exposing (Function)
+import Elm.Syntax.Type exposing (Type)
+import Elm.Syntax.TypeAlias exposing (TypeAlias)
+
+
+
+-- Type Alias
+
+
+encoderForTypeAlias : TypeAlias -> Function
+encoderForTypeAlias _ =
+    Debug.todo "not implemented yet"
+
+
+decoderForTypeAlias : TypeAlias -> Function
+decoderForTypeAlias _ =
+    Debug.todo "not implemented yet"
+
+
+
+-- Custom Type
+
+
+encoderForCustomType : Type -> Function
+encoderForCustomType _ =
+    Debug.todo "not implemented yet"
+
+
+decoderForCustomType : Type -> Function
+decoderForCustomType _ =
+    Debug.todo "not implemented yet"


### PR DESCRIPTION
This work addresses #19 by generating the required (and annoying) boilerplate to make full use of these devtools:
1. JSON encoder/decoder for messages. `decode (encode msg) == msg` should always be true - otherwise fail in a clear and informative way.
2. JSON encoder for the model. If values are opaque, simply write them out as a string.
3. JSON decoder for the model. It is unclear to me exactly how this should work, but probably something along the lines of unlocking a write-mode for the model, where you can:
    1. Pause the app and replace a value in the model.
    4. Replay any previous state with that replacement.
    5. Continue the app from that previous state without the replacement.

This approach will initially be based on static-analysis of code, but could probably be done (better?) with [`stoeffel/elmi-to-json`](https://github.com/stoeffel/elmi-to-json), which statically analyses the build-cache.